### PR TITLE
fix: use package name from metadata file as package name

### DIFF
--- a/src/monas/commands/bump.py
+++ b/src/monas/commands/bump.py
@@ -133,7 +133,7 @@ def bump(
     info(f"Will bump version for [primary]{len(packages)}[/] package(s)")
     for pkg in packages:
         console.print(
-            f"  [primary]{pkg.path.name}[/] [succ]{pkg.version}[/] -> "
+            f"  [primary]{pkg.name}[/] [succ]{pkg.version}[/] -> "
             f"[succ]{version}[/]"
         )
     if not Confirm.ask("Continue?", console=console, default=True):

--- a/src/monas/commands/common.py
+++ b/src/monas/commands/common.py
@@ -66,7 +66,7 @@ def list_packages(
     """List the packages."""
     if json:
         data = [
-            {"name": pkg.path.name, "version": pkg.version, "path": pkg.path.as_posix()}
+            {"name": pkg.name, "version": pkg.version, "path": pkg.path.as_posix()}
             for pkg in packages
         ]
         console.print_json(data=data)
@@ -76,7 +76,7 @@ def list_packages(
         table.add_column("Version")
         table.add_column("Path", overflow="fold")
     for pkg in packages:
-        row = [f"[primary]{pkg.path.name}[/]"]
+        row = [f"[primary]{pkg.name}[/]"]
         if long:
             row.append(f"[succ]{pkg.version}[/]")
             row.append(f"[info]{pkg.path.relative_to(pkg.config.path).as_posix()}[/]")

--- a/src/monas/commands/install.py
+++ b/src/monas/commands/install.py
@@ -46,11 +46,11 @@ def install(config: Config, *, concurrency: int, root: bool, **kwargs: Any) -> N
     def _on_complete(project: PyPackage, future: Future) -> None:
         if future.exception():
             console.print(
-                f" [red bold]FAIL[/] {project.path.name} {future.exception()}"
+                f" [red bold]FAIL[/] {project.name} {future.exception()}"
             )
             errors.append(future.exception())
         else:
-            console.print(f" [succ]SUCC[/] {project.path.name}")
+            console.print(f" [succ]SUCC[/] {project.name}")
 
     with console.status(
         f"Installing [primary]{package_count}[/] package(s)", spinner="point"

--- a/src/monas/commands/new.py
+++ b/src/monas/commands/new.py
@@ -28,7 +28,7 @@ def new(
     """
     if location is None:
         location = config.package_paths[0]
-    if any(package == pkg.path.name for pkg in config.iter_packages()):
+    if any(package == pkg.name for pkg in config.iter_packages()):
         raise click.BadParameter(f"{package} already exists")
     package_path = Path(location, package).absolute()
     repo = config.get_repo()

--- a/src/monas/commands/publish.py
+++ b/src/monas/commands/publish.py
@@ -70,7 +70,7 @@ def publish(
         index = f"[succ]{repository}[/]"
     info(f"The following packages are to be built and published to {index}:")
     for pkg in packages_to_publish:
-        console.print(f"  [primary]{pkg.path.name}[/] [succ]{pkg.version}[/]")
+        console.print(f"  [primary]{pkg.name}[/] [succ]{pkg.version}[/]")
     if not Confirm.ask("Continue?", console=console, default=True):
         ctx.abort()
     dist = config.path / "dist"

--- a/src/monas/metadata/base.py
+++ b/src/monas/metadata/base.py
@@ -27,6 +27,11 @@ class Metadata(metaclass=abc.ABCMeta):
         """Get the project version"""
         pass
 
+    @abc.abstractproperty
+    def package_name(self) -> str:
+        """Get the project version"""
+        pass
+
     @version.setter
     def version(self, value: str) -> None:
         """Set the project version"""

--- a/src/monas/metadata/pep621.py
+++ b/src/monas/metadata/pep621.py
@@ -34,6 +34,10 @@ class PEP621Metadata(Metadata):
     def version(self) -> str:
         return self._data["project"]["version"]
 
+    @property
+    def package_name(self) -> str:
+        return self._data["project"]["name"]
+
     @version.setter
     def version(self, value: str) -> None:
         self._data["project"]["version"] = value

--- a/src/monas/metadata/setupcfg.py
+++ b/src/monas/metadata/setupcfg.py
@@ -41,6 +41,10 @@ class SetupCfgMetadata(Metadata):
     def version(self) -> str:
         return self._parser.get("metadata", "version")
 
+    @property
+    def package_name(self) -> str:
+        return self._parser.get("metadata", "name")
+
     @version.setter
     def version(self, value: str) -> None:
         self._parser["metadata"]["version"] = value

--- a/src/monas/project.py
+++ b/src/monas/project.py
@@ -92,9 +92,14 @@ class PyPackage:
         return cast(Type[Metadata], result)(self.path)
 
     @property
+    def name(self) -> str:
+        """Get the project name"""
+        return self.metadata.package_name
+
+    @property
     def canonical_name(self) -> str:
         """Get the project name"""
-        return canonicalize_name(self.path.name)
+        return canonicalize_name(self.name)
 
     @property
     def version(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,26 +46,29 @@ def python_version():
 @pytest.fixture()
 def test_project(cli_run, project):
     run_command(["git", "init"], cwd=str(project))
-    with mock.patch(
-        "monas.commands.new.ask_for",
-        side_effect=[
-            {
-                "name": "foo",
-                "version": "0.0.0",
-                "author": "John",
-                "author_email": "john@doe.me",
-                "description": "Test Project",
-                "license_expr": "MIT",
-                "homepage": "https://example.org",
-                "requires_python": ">=3.7",
-                "build_backend": backend,
-            }
-            for backend in ["setuptools(setup.cfg)", "pdm", "flit"]
-        ],
-    ):
-        cli_run(["new", "foo"], cwd=project, input="\n")
-        cli_run(["new", "bar"], cwd=project, input="\n")
-        cli_run(["new", "foo-more", "extras"], cwd=project, input="\n")
+    projects = (
+        (("new", "foo"), "setuptools(setup.cfg)"),
+        (("new", "bar"), "pdm"),
+        (("new", "foo-more", "extras"), "flit"),
+    )
+    for cli_args, backend in projects:
+        with mock.patch(
+            "monas.commands.new.ask_for",
+            side_effect=[
+                {
+                    "name": cli_args[1],
+                    "version": "0.0.0",
+                    "author": "John",
+                    "author_email": "john@doe.me",
+                    "description": "Test Project",
+                    "license_expr": "MIT",
+                    "homepage": "https://example.org",
+                    "requires_python": ">=3.7",
+                    "build_backend": backend,
+                }
+            ],
+        ):
+            cli_run(cli_args, cwd=project, input="\n")
     run_command(["git", "add", "."], cwd=str(project))
     run_command(["git", "commit", "-m", "Initial commit"], cwd=str(project))
     return project


### PR DESCRIPTION
When evaluating local package names in PyPackage.install(), a package's "canonical_name" should reference the package name from the metadata file, not the parent directory of the package.

# Motivation
I tried linking a library to another library using namespace packages (eg `acme.lib-a`). The existing [`install()` function](https://github.com/frostming/monas/blob/main/src/monas/project.py#L156) compared the `pkg.canonical_name` with the name listed in the dependencies. The [`pkg.canonical_name`](https://github.com/frostming/monas/blob/main/src/monas/project.py#L97) was returning the parent directory of the package, relying on the package parent directory to have the same name as the python package. This is not always going to be the same as the package name, as some developers have different parent directory names than their project name. I added a property to the metadata classes to provide the package name as reported by the metadata file. I called this property `package_name`, as [`name`](https://github.com/frostming/monas/blob/main/src/monas/metadata/base.py#L13) was already a property for the class. I considered renaming the existing `name` property to something else, like `type`, but didn't want to create too many changes. It's a bit confusing that the Metadata classes contain properties that describe the metadata file itself (eg "name" and "filename") and properties that describe the python package (like "version")

I also updated a test case that was creating demo packages that all had the name "foo". This caused the tests to "add" a dependency fail, because adding "foo" to any project would cause a circular dependency (since all demo projects were named "foo" in their metadata file.)

This highlights that guardrails should probably be added that prevent self dependencies, or circular dependencies.