### PR TITLE
fix: remove license-expression syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python monorepo made easy"
 authors = [
     {name = "Frost Ming", email = "mianghong@gmail.com"}
 ]
-license-expression = "MIT"
+license = {text = "MIT"}
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [


### PR DESCRIPTION
[A test on another PR](https://github.com/frostming/monas/actions/runs/5696122856/job/15447082249?pr=4) failed due to `license-expression` being used in the `pyproject.toml`. This updates the syntax of the license field to be valid. 