### PR TITLE
fix: directory is not package unless contains metadata file

### DIFF
--- a/src/monas/config.py
+++ b/src/monas/config.py
@@ -90,7 +90,11 @@ class Config:
         for p in self.package_paths:
             for package in p.iterdir():
                 if package.is_dir():
-                    yield PyPackage(self, package)
+                    pypackage = PyPackage(self, package)
+                    if not pypackage.metadata.path.is_file():
+                        # directory has no python metadata file, ignore
+                        continue
+                    yield pypackage
 
 
 pass_config = click.make_pass_decorator(Config, ensure=True)


### PR DESCRIPTION
`iter_packages` previously considered any directory in a package_path to be a package.
This adds a check that the metadata.path is a file before considering the directory to be a package.

When monas loads its configuration from the top level `pyproject.toml`, it reads the "packages" field to find local packages via the [`package_paths`](https://github.com/frostming/monas/blob/main/src/monas/config.py#L62) property. 
`iter_packages` will scan the `package_paths`, and [check if each one is a directory](https://github.com/frostming/monas/blob/main/src/monas/config.py#L92) before [turning it into a `PyPackage` class](https://github.com/frostming/monas/blob/main/src/monas/config.py#L93) and yielding it as one of the local monorepo packages. 

The `PyPackage` class will initialize just fine when provided an empty directory. This behavior starts with a [check if there is a `pyproject.toml` file](https://github.com/frostming/monas/blob/main/src/monas/project.py#L84), and if one is not found, it will [set its metadata to an empty dict](https://github.com/frostming/monas/blob/main/src/monas/project.py#L86). The `SetupCfgMetadata` class's `match` function will [return `True` if provided such an empty dict](https://github.com/frostming/monas/blob/main/src/monas/metadata/setupcfg.py#L24). This means an empty directory scanned by `iter_packages` will be initialized as a valid setupcfg project, even in there is no matching `setup.cfg` file contained in the directory.

I think there may be an argument to preventing this class from initializing at all if there is not a valid `setup.cfg` file contained in the directory. I wasn't sure if the existing logic was intentional, so I didn't change it. 

Instead, I just added a check to `iter_packages` that verifies that the expected metadata file exists before returning it as a package. 