### PR TITLE
fix: correct spelling of pyproject.toml in build backend choices prompt

### DIFF
--- a/src/monas/questions.py
+++ b/src/monas/questions.py
@@ -58,7 +58,7 @@ package_questions = {
         "Build backend:",
         choices=[
             "setuptools(setup.cfg)",
-            "setuptools(pyprojec.toml)",
+            "setuptools(pyproject.toml)",
             "pdm",
             "flit",
             "hatch",


### PR DESCRIPTION
The prompt misspelled `pyproject.toml` which caused new packages to be created with config.cfg (as it was the default): https://github.com/frostming/monas/blob/main/src/monas/project.py#L65

This fixes the spelling to fix the bug.