### PR TITLE
fix: add recursion checks to prevent dependency loops

### DIFF
--- a/src/monas/project.py
+++ b/src/monas/project.py
@@ -163,7 +163,7 @@ class PyPackage:
 
     def get_local_dependencies(
         self,
-        local_dependencies: Optional[list[PyPackage]]=None,
+        local_dependencies: list[PyPackage] | None = None,
     ) -> list[PyPackage]:
         """Return list of local dependencies.
 


### PR DESCRIPTION
- the dependency resolver is recursive which allow for detecting transitive dependencies
- the recursive dependency search now keeps an accumulator of all seen dependencies, to prevent duplicate entries in case multiple packages depend on the same local package
- a check is also added to prevent a package from listing itself as a dependency, which would cause an infinite recursive loop