### PR TITLE
BREAKING CHANGE: use glob patterns for package identification

### DIFF
--- a/src/monas/commands/init.py
+++ b/src/monas/commands/init.py
@@ -24,8 +24,9 @@ def init(*, version: str, python_version: str) -> None:
     Args:
         path: The path to the `pyproject.toml` file.
     """
+    default_package_dirs = ["packages"]
     mono_settings = {
-        "packages": ["packages/"],
+        "packages": [f"{pb}/*" for pb in default_package_dirs],
         "version": version,
         "python-version": python_version,
     }
@@ -39,7 +40,7 @@ def init(*, version: str, python_version: str) -> None:
     info(f"{verb} {pyproject_toml.name}")
     doc.setdefault("tool", {}).setdefault("monas", {}).update(mono_settings)
     pyproject_toml.write_text(tomlkit.dumps(doc))
-    for p in mono_settings["packages"]:
+    for p in default_package_dirs:
         p = Path(p)
         if not p.exists():
             info(f"Creating {p.name}")

--- a/src/monas/commands/new.py
+++ b/src/monas/commands/new.py
@@ -26,7 +26,7 @@ def new(
 
     If location isn't given, it defaults to the first location of `packages` config.
     """
-    parent_dir = Path(config.default_package_dir)
+    parent_dir = config.default_package_dir
     if location is not None:
         parent_dir = Path(location)
 

--- a/src/monas/commands/new.py
+++ b/src/monas/commands/new.py
@@ -26,11 +26,14 @@ def new(
 
     If location isn't given, it defaults to the first location of `packages` config.
     """
-    if location is None:
-        location = config.package_paths[0]
+    parent_dir = Path(config.default_package_dir)
+    if location is not None:
+        parent_dir = Path(location)
+
     if any(package == pkg.name for pkg in config.iter_packages()):
         raise click.BadParameter(f"{package} already exists")
-    package_path = Path(location, package).absolute()
+
+    package_path = (parent_dir / package).absolute()
     repo = config.get_repo()
 
     default_values = {
@@ -63,5 +66,5 @@ def new(
         f.write(metadata_contents)
     info("Creating project files")
     PyPackage.create(config, package_path, inputs)
-    if location not in config.package_paths:
-        config.add_package_path(location)
+
+    config.add_package_path(parent_dir)

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -4,7 +4,7 @@ def test_init_with_default_python_version(cli_run, tmp_path, python_version):
         tmp_path.joinpath("pyproject.toml").read_text()
         == f"""\
 [tool.monas]
-packages = ["packages/"]
+packages = ["packages/*"]
 version = "0.0.0"
 python-version = "{python_version}"
 """
@@ -17,7 +17,7 @@ def test_init_with_given_python_version(cli_run, tmp_path):
         tmp_path.joinpath("pyproject.toml").read_text()
         == """\
 [tool.monas]
-packages = ["packages/"]
+packages = ["packages/*"]
 version = "0.0.0"
 python-version = "3.9"
 """

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -144,7 +144,7 @@ def test_new_package_under_non_default_location(project, cli_run, python_version
         project.joinpath("pyproject.toml").read_text()
         == f"""\
 [tool.monas]
-packages = ["packages/", "others/"]
+packages = ["packages/*", "others/*"]
 version = "0.0.0"
 python-version = "{python_version}"
 """


### PR DESCRIPTION
Monas currently expects the top level config to contain a "packages" field that contains the relative path of the directory that contains python packages.

This changes the field to look for glob patterns that point to python package directories instead. This makes it [behave more like Lerna](https://lerna.js.org/docs/api-reference/configuration#packages), the inspiration for this project.

It also allows for the root directory to contain a project, which solves this problem: https://github.com/frostming/monas/issues/12

This also gives user the flexibility to do something like 
```
packages = ["packages/acme-*"]
```
if they wanted to be specific about which directories monas should look inside.