### PR TITLE
Feature: Specifying multiple or no package directories for `monas init`

### DIFF
--- a/src/monas/commands/init.py
+++ b/src/monas/commands/init.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 from pathlib import Path
 

--- a/src/monas/commands/init.py
+++ b/src/monas/commands/init.py
@@ -18,13 +18,35 @@ from monas.utils import get_preferred_python_version, info
     help="The Python version to use",
 )
 @click.option("-v", "--version", default="0.0.0", help="The version of the monorepo")
-def init(*, version: str, python_version: str) -> None:
+@click.option(
+    "-d",
+    "--default-package-dir",
+    multiple=True,
+    default=["packages"],
+    help="Default Package Directories to be created",
+)
+@click.option(
+    "-n",
+    "--no-package-dir",
+    is_flag=True,
+    default=False,
+    help="If specified, no package directories will be created",
+)
+def init(
+    *,
+    version: str,
+    python_version: str,
+    default_package_dir: list[str],
+    no_package_dir: bool,
+) -> None:
     """Initialize the monas tool.
 
     Args:
         path: The path to the `pyproject.toml` file.
     """
-    default_package_dirs = ["packages"]
+    default_package_dirs = list(default_package_dir)
+    if no_package_dir:
+        default_package_dirs.clear()
     mono_settings = {
         "packages": [f"{pb}/*" for pb in default_package_dirs],
         "version": version,

--- a/src/monas/project.py
+++ b/src/monas/project.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 from shlex import join as sh_join
-from typing import Optional, Type, cast
+from typing import Type, cast
 
 import tomlkit
 from packaging.utils import canonicalize_name
@@ -179,7 +179,7 @@ class PyPackage:
             if pkg_name not in dependency_names:
                 continue
             if pkg_name == self.canonical_name:
-                raise ValueError(f'{self.name} cannot have a dependency on itself')
+                raise ValueError(f"{self.name} cannot have a dependency on itself")
             if pkg_name in [ld.canonical_name for ld in local_dependencies]:
                 continue
             local_dependencies = [pkg, *local_dependencies]

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -26,7 +26,6 @@ python-version = "3.9"
 
 def test_init_with_no_package_directories(cli_run, tmp_path):
     cli_run(["init", "-n", "-p", "3.9"], cwd=tmp_path)
-    print("CLI TEST_RAN")
     assert (
         tmp_path.joinpath("pyproject.toml").read_text()
         == """\

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -22,3 +22,35 @@ version = "0.0.0"
 python-version = "3.9"
 """
     )
+
+
+def test_init_with_no_package_directories(cli_run, tmp_path):
+    cli_run(["init", "-n", "-p", "3.9"], cwd=tmp_path)
+    print("CLI TEST_RAN")
+    assert (
+        tmp_path.joinpath("pyproject.toml").read_text()
+        == """\
+[tool.monas]
+packages = []
+version = "0.0.0"
+python-version = "3.9"
+"""
+    )
+
+
+def test_init_with_selected_package_directories(cli_run, tmp_path):
+    cli_run(["init", "-p", "3.9", "-d", "packages1", "-d", "packages2"], cwd=tmp_path)
+    print("CLI TEST_RAN")
+    assert (
+        tmp_path.joinpath("pyproject.toml").read_text()
+        == """\
+[tool.monas]
+packages = ["packages1/*", "packages2/*"]
+version = "0.0.0"
+python-version = "3.9"
+"""
+    )
+    import os
+
+    assert os.path.exists(os.path.join(tmp_path, "packages1"))
+    assert os.path.exists(os.path.join(tmp_path, "packages2"))


### PR DESCRIPTION
This includes the ability to control package directories when using `monas init`.
Two new options are available for `monas init`:
- `-d`/`--default-package-dir`: specify one or more package dirs, default value is `packages`
  ```
  $ monas init -d packagedir1 --default-package-dir packagedir2
  monas Creating pyproject.toml
  monas Creating packagedir1
  monas Creating packagedir2
  monas Creating project files
  ```
- `-n`/`--no-package-dir`: this will not add any package directories, and overrides behaviour of `-d`
  ```
  $ monas init -n
  monas Creating pyproject.toml
  monas Creating project files
  ```
