### PR TITLE
Feature: Support Adding explicit package entries using option in `monas new`

### DIFF
--- a/src/monas/commands/new.py
+++ b/src/monas/commands/new.py
@@ -15,10 +15,23 @@ from monas.utils import console, err_console, info
 @click.command()
 @click.argument("package", required=True)
 @click.argument("location", required=False)
+@click.option(
+    "-e",
+    "--explicit-package-entry",
+    is_flag=True,
+    default=False,
+    help="If specified, an explicit package entry "
+    + "will be added to the list of packages",
+)
 @pass_config
 @pass_context
 def new(
-    ctx: click.Context, config: Config, *, package: str, location: str | None = None
+    ctx: click.Context,
+    config: Config,
+    *,
+    package: str,
+    location: str | None = None,
+    explicit_package_entry: bool,
 ):
     """Create a new <package> under <location>.
 
@@ -67,4 +80,7 @@ def new(
     info("Creating project files")
     PyPackage.create(config, package_path, inputs)
 
-    config.add_package_path(parent_dir)
+    if explicit_package_entry:
+        config.add_explicit_package_path(package_path)
+    else:
+        config.add_package_path(parent_dir)

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -149,3 +149,29 @@ version = "0.0.0"
 python-version = "{python_version}"
 """
     )
+
+
+@pytest.mark.usefixtures("mock_input")
+def test_new_package_with_explicit_path(project, cli_run, python_version):
+    """
+    Create a new project with explicit path entry
+    """
+    cli_run(["new", "-e", "first", "."], cwd=project, input="\n")
+    cli_run(["new", "-e", "second", "."], cwd=project, input="\n")
+    cli_run(["new", "-e", "third", "nested"], cwd=project, input="\n")
+    packages = [
+        ("first", project.joinpath("first")),
+        ("second", project.joinpath("second")),
+        ("third", project.joinpath("nested/third")),
+    ]
+    for _package_name, package_path in packages:
+        assert package_path.is_dir()
+    assert (
+        project.joinpath("pyproject.toml").read_text()
+        == f"""\
+[tool.monas]
+packages = ["packages/*", "first", "second", "nested/third"]
+version = "0.0.0"
+python-version = "{python_version}"
+"""
+    )

--- a/tests/cli/test_new.py
+++ b/tests/cli/test_new.py
@@ -152,6 +152,7 @@ python-version = "{python_version}"
 
 
 @pytest.mark.usefixtures("mock_input")
+@pytest.mark.parametrize("backend", ["setuptools(pyproject.toml)"])
 def test_new_package_with_explicit_path(project, cli_run, python_version):
     """
     Create a new project with explicit path entry


### PR DESCRIPTION
This pull request adds a flag option to `monas new` subcommand, which adds an explicit package entry in the root project
```
$ monas new --help
                                                                                                                                            
 Usage: monas new [OPTIONS] PACKAGE [LOCATION]                                                                                              
                                                                                                                                            
 Create a new <package> under <location>.                                                                                                   
 The package name must be locally unique and available on PyPI.                                                                             
 If location isn't given, it defaults to the first location of `packages` config.                                                           
                                                                                                                                            
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --explicit-package-entry  -e    If specified, an explicit package entry will be added to the list of packages                            │
│ --help                          Show this message and exit.                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

Example Usage:
The following commands will produce the following root `pyproject.toml`
```
$ monas init -n
$ monas new -e service binaries
$ monas new -e utils common
$ monas new -e sample .
```

```toml
[tool.monas]
packages = ["binaries/service", "common/utils", "sample"]
version = "0.0.0"
python-version = "3.11"
```