### PR TITLE
Support for `optional dependencies`

### DIFF
--- a/src/monas/commands/install.py
+++ b/src/monas/commands/install.py
@@ -38,7 +38,10 @@ def install(config: Config, *, concurrency: int, root: bool, **kwargs: Any) -> N
             f"Installing [primary]{package_count}[/] package(s) to the root project",
             spinner="point",
         ):
-            requirements = (sh_join(["-e", pkg.path.as_posix()]) for pkg in packages)
+            requirements = (
+                f"{sh_join(['-e', pkg.path.as_posix()])}{config.extra_str_for_package(pkg.name)}"
+                for pkg in packages
+            )
             pip_install(config.root_venv, requirements)
         info("[succ]Installation done[/]")
         return

--- a/src/monas/commands/install.py
+++ b/src/monas/commands/install.py
@@ -39,7 +39,7 @@ def install(config: Config, *, concurrency: int, root: bool, **kwargs: Any) -> N
             spinner="point",
         ):
             requirements = (
-                f"{sh_join(['-e', pkg.path.as_posix()])}{config.extra_str_for_package(pkg.name)}"
+                f"{sh_join(['-e', pkg.path.as_posix()])}{config.extra_str_for_package(pkg.path.name)}"
                 for pkg in packages
             )
             pip_install(config.root_venv, requirements)

--- a/src/monas/config.py
+++ b/src/monas/config.py
@@ -6,6 +6,7 @@ import sys
 import typing
 from pathlib import Path
 from typing import Iterable
+from functools import cached_property
 
 import click
 from tomlkit.toml_file import TOMLFile
@@ -61,7 +62,7 @@ class Config:
         """Get the git repository."""
         return Git(self.path)
 
-    @property
+    @cached_property
     def packages_extra_dict(self) -> dict:
         """
         Creates a dictionary mapping package names to their extras.
@@ -150,7 +151,8 @@ class Config:
 
     def extra_str_for_package(self, package_name: str) -> str:
         with contextlib.suppress(KeyError):
-            return f"[{','.join(self.packages_extra_dict[package_name])}]"
+            extras = self.packages_extra_dict[package_name]
+            return f"[{','.join(extras)}]" if extras else ""
         return ""
 
     def iter_packages(self) -> Iterable[PyPackage]:


### PR DESCRIPTION
Pretty simple PR - just adds support for this:

`pyproject.toml`

```toml
[tool.monas]
packages = [
    "packageA[dev,test]",
    "packageB[fastAPI]",
]
version = "0.0.1"
python-version = "3.13"
```

Without these changes, impossible to install extra dependencies